### PR TITLE
fix etcd configuration to support ipv6

### DIFF
--- a/salt/_modules/patroni_helpers.py
+++ b/salt/_modules/patroni_helpers.py
@@ -26,6 +26,7 @@ Helpers for our patroni cluster
 
 import re
 import os.path
+import ipaddress
 from salt.modules.jinja import import_yaml
 
 cached_default_settings = None
@@ -182,6 +183,11 @@ def settings(pillar_postgresql, pgbackrest_stanza):
 
 
 def get_etcd_url(minion_id, hostname, protocol, port ):
+    try:
+        if ipaddress.ip_address(hostname).version == 6:
+            hostname = f"[{hostname}]" 
+    except ValueError:
+        pass
     return "{minion_id}={protocol}://{hostname}:{port}".format(minion_id=minion_id, protocol=protocol, hostname=hostname, port=port)
 
 

--- a/salt/patroni/files/etc/default/etcd.j2
+++ b/salt/patroni/files/etc/default/etcd.j2
@@ -1,12 +1,19 @@
 {%- set own_ip                   = salt['mine.get'](grains.id, pillar_etcd.etcd_address_mine_function)[grains.id][0] %}
 
+{%- set own_ip_is_ipv6 = ':' in own_ip %}
+{%- if own_ip_is_ipv6 %}
+  {%- set formatted_peer_ip = '[' ~ own_ip ~ ']' %}
+{%- else %}
+  {%- set formatted_peer_ip = own_ip %}
+{%- endif %}
+
 {%- set etcd_cluster_urls        =  salt['patroni_helpers.mine_etcd_cluster_url'](pillar_etcd.etcd_cluster_role, pillar_etcd.etcd_address_mine_function) %}
 
 {%- set etcd_own_host_client_url = pillar_etcd.protocol ~ '://' ~ grains.id ~ ':' ~ pillar_etcd.client_port %}
-{%- set etcd_own_ip_client_url   = pillar_etcd.protocol ~ '://' ~ own_ip ~ ':' ~ pillar_etcd.client_port %}
+{%- set etcd_own_ip_client_url   = pillar_etcd.protocol ~ '://' ~ formatted_peer_ip ~ ':' ~ pillar_etcd.client_port %}
 
 {%- set etcd_own_host_peer_url   = pillar_etcd.protocol ~ '://' ~ grains.id ~ ':' ~ pillar_etcd.peer_port   %}
-{%- set etcd_own_ip_peer_url     = pillar_etcd.protocol ~ '://' ~ own_ip ~ ':' ~ pillar_etcd.peer_port   %}
+{%- set etcd_own_ip_peer_url     = pillar_etcd.protocol ~ '://' ~ formatted_peer_ip ~ ':' ~ pillar_etcd.peer_port   %}
 
 {%- set cacert = salt['patroni_helpers.cacert']('etcd') %}
 


### PR DESCRIPTION
This fix ensures that only valid IPv6 addresses are properly formatted by enclosing them in square brackets ([ ]), as required by the etcd URL specification. If the address is not a valid IPv6 address (e.g. IPv4 or hostname), no changes will be applied.

Before:
```
...
ETCD_LISTEN_PEER_URLS="https://2a07:de40:b281:6b::101:2380"
ETCD_LISTEN_CLIENT_URLS="https://2a07:de40:b281:6b::101:2379,https://localhost:2379"
...
ETCD_INITIAL_CLUSTER="pandora02-dev.dmz-prg2.suse.org=https://2a07:de40:b281:6b::102:2380,pandora01-dev.dmz-prg2.suse.org=https://2a07:de40:b281:6b::101:2380,pandora03-dev.dmz-prg2.suse.org=https://2a07:de40:b281:6b::103:2380"
...
```

After:
```
...
ETCD_LISTEN_PEER_URLS="https://[2a07:de40:b281:6b::101]:2380"
ETCD_LISTEN_CLIENT_URLS="https://[2a07:de40:b281:6b::101]:2379,https://localhost:2379"
...
ETCD_INITIAL_CLUSTER="pandora02-dev.dmz-prg2.suse.org=https://[2a07:de40:b281:6b::102]:2380,pandora01-dev.dmz-prg2.suse.org=https://[2a07:de40:b281:6b::101]:2380,pandora03-dev.dmz-prg2.suse.org=https://[2a07:de40:b281:6b::103]:2380"
...
``
This change ensures proper etcd parsing and avoids potential issues with unbracketed IPv6 addresses.