### PR TITLE
Ndachev/extend standby cluster cfg

### DIFF
--- a/salt/patroni/files/etc/patroni.yml.j2
+++ b/salt/patroni/files/etc/patroni.yml.j2
@@ -59,14 +59,12 @@ bootstrap:
     {% if 'is_standby' in pillar_patroni.config and pillar_patroni.config.is_standby %}
     standby_cluster:
       host: {{ pillar_patroni.config.standby_primary }}
-      port: 5432
-      restore_command: '/usr/bin/pgbackrest --stanza={{ pgbackrest_stanza }} archive-get %f "%p"'
+      port: {{ pillar_patroni.config.port | default(5432) }}
+      restore_command: {{ pillar_patroni.config.restore_command | default("/usr/bin/pgbackrest --stanza=" ~ pgbackrest_stanza ~ " archive-get %f \"%p\"") }}
       # this needs to be manually created
-      primary_slot_name: patroni_standby
+      primary_slot_name: {{ pillar_patroni.config.primary_slot_name | default('patroni_standby') }}
       # in theory we can use the same fallthrough as in the postgresql section below
-      create_replica_methods:
-      - pgbackrest
-      - basebackup
+      create_replica_methods: {{ pillar_patroni.config.create_replica_methods | default(['pgbackrest', 'basebackup']) }}
     {% endif %}
     postgresql:
       # https://www.postgresql.org/docs/14/app-pgrewind.html

--- a/salt/patroni/init.sls
+++ b/salt/patroni/init.sls
@@ -73,6 +73,15 @@ postgresql_instances_dir:
     - require:
       - postgresql_packages
 
+postgresql_data_directory:
+  file.directory:
+    - name: {{ postgresql_data_directory }}
+    - user: postgres
+    - group: postgres
+    - mode: '0700'
+    - require:
+      - file: postgresql_instances_dir
+
 {%- set sysconfig_setting = "POSTGRES_DATADIR" %}
 sysconfig_postgresql_datadir:
   file.replace:


### PR DESCRIPTION
- Add creation of missing PostgreSQL data_directory to prevent state.apply failure when directory is not created manually.  
- Update standby_cluster configuration to use pillar variables with sane defaults.  
  Keeps existing values as defaults.  
  Makes standby_cluster configuration more flexible and easier to override.  