### PR TITLE
fix PostgreSQL slots configuration in Patroni template

### DIFF
--- a/salt/patroni/files/etc/patroni.yml.j2
+++ b/salt/patroni/files/etc/patroni.yml.j2
@@ -110,9 +110,9 @@ bootstrap:
         - createdb
 
 postgresql:
-{%- if pillar_patroni.config.postgresql.slots %}
+{%- if pillar_postgresql.slots %}
   slots:
-{{ pillar_patroni.config.postgresql.slots | yaml(False) | indent(4, true) }}
+{{ pillar_postgresql.slots | yaml(False) | indent(4, true) }}
 {%- endif %}
   create_replica_methods:
     - pgbackrest


### PR DESCRIPTION
- use correct pillar helper function

test results:

```
----------
          ID: patroni_config
    Function: file.managed
        Name: /etc/patroni.yml
      Result: None
     Comment: The file /etc/patroni.yml is set to be changed
              Note: No changes made, actual changes may
              be different due to other states.
     Started: 14:24:25.076465
    Duration: 111.081 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -137,6 +137,9 @@
                           - createdb
                   
                   postgresql:
                  +  slots:
                  +    patroni_standby:
                  +      type: physical
                     create_replica_methods:
```